### PR TITLE
Update app backend URL

### DIFF
--- a/src/appConfig.ts
+++ b/src/appConfig.ts
@@ -1,7 +1,7 @@
 const appConfig: {
   backendUrl: string;
 } = {
-  backendUrl: 'https://directus.bula21.ch',
+  backendUrl: 'https://app-backend.mova.ch',
   //backendUrl: 'http://backend.pio-x.ch:8885',
 };
 export default appConfig;


### PR DESCRIPTION
Die alte Instanz von Directus läuft nicht mehr, daher müssen wir die URL anpassen.