### PR TITLE
Subpages using markdown links

### DIFF
--- a/src/components/generic/MovaMarkdown.tsx
+++ b/src/components/generic/MovaMarkdown.tsx
@@ -2,6 +2,9 @@ import React, {ReactNode} from 'react';
 import Markdown from 'react-native-markdown-display';
 import {Platform, StyleSheet} from 'react-native';
 import MovaTheme from "../../constants/MovaTheme";
+import { StackNavigationProp } from '@react-navigation/stack';
+import { IPage } from '../infos/IPage';
+import { InfopagesStore } from '../../stores/InfopagesStore';
 
 const fontFamily = Platform.OS === 'ios' ? 'MessinaSans-Bold' : 'MS-Bold';
 
@@ -91,8 +94,34 @@ const styles = StyleSheet.create({
 
 type Props = {
   children: ReactNode;
+  navigation: StackNavigationProp<
+    {infopage: {page: IPage}},
+    'infopage'
+  >;
 };
 
 export default function MovaMarkdown(props: Props) {
-  return <Markdown style={styles}>{props.children}</Markdown>;
+
+  const clickMarkdownLink = (url: string): boolean => {
+    const id = Number(url);
+    if (Number.isNaN(id)) {
+      // return true to open URL as usual
+      return true
+    }
+    const page = InfopagesStore.getPage(id);
+    if (page) {
+      props.navigation.push(
+        'infopage', { page }
+      );
+    }
+    // return false to prevent default
+    return false;
+  }  
+
+  return <Markdown
+    style={styles}
+    onLinkPress={clickMarkdownLink}
+  >
+    {props.children}
+  </Markdown>;
 }

--- a/src/components/infos/IPage.ts
+++ b/src/components/infos/IPage.ts
@@ -5,4 +5,5 @@ export interface IPage {
   renderer: string | null;
   data: any;
   list_color: string;
+  sub_page: boolean;
 }

--- a/src/components/infos/InfosList.tsx
+++ b/src/components/infos/InfosList.tsx
@@ -53,6 +53,14 @@ type NavigationProp = StackNavigationProp<
   'infopage'
 >;
 
+function mainPageFilter(page: IPage) : boolean {
+  return page.sub_page === false;
+}
+
+function mainPages() : IPage[] {
+  return InfopagesStore.get().filter(mainPageFilter);
+}
+
 export default function InfosList({navigation}: {navigation: NavigationProp}) {
   const {t} = useTranslation();
 
@@ -66,9 +74,9 @@ export default function InfosList({navigation}: {navigation: NavigationProp}) {
 
   // load on mount
   useEffect(() => {
-    setPages(InfopagesStore.get());
+    setPages(mainPages());
     const subscription = InfopagesStore.subscribe((pages: IPage[]) => {
-      setPages(pages);
+      setPages(pages.filter(mainPageFilter));
     })
     InfopagesStore.reload();
     return () => {
@@ -85,7 +93,7 @@ export default function InfosList({navigation}: {navigation: NavigationProp}) {
   function onRefresh() {
     setRefreshing(true);
     InfopagesStore.reload().then(() => {
-      setPages(InfopagesStore.get());
+      setPages(mainPages());
       setRefreshing(false);
     });
   }
@@ -112,7 +120,7 @@ export default function InfosList({navigation}: {navigation: NavigationProp}) {
   };
 
   function leaveSearch() {
-    onNewSearchKeyword("");
+    onNewSearchKeyword('');
     setSearching(false);
     animationProgress.setValue(1);
     Animated.timing(animationProgress, {
@@ -125,6 +133,11 @@ export default function InfosList({navigation}: {navigation: NavigationProp}) {
 
   function onNewSearchKeyword(keyword: string) {
     setSearchKeyword(keyword);
+    if (keyword === '') {
+      setPages(mainPages());
+      return;
+    }
+    // Search shows all pages, including sub pages
     let pages = InfopagesStore.get();
     if (isSearchActive && typeof keyword != 'undefined' && keyword) {
       const sanitized = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/components/infos/InfosPage.tsx
+++ b/src/components/infos/InfosPage.tsx
@@ -16,20 +16,16 @@ export default function InfosPage({route, navigation}: Props) {
 
   // load from store on mount
   useEffect(() => {
-    setPage(getPage(route.params.page.id));
+    setPage(InfopagesStore.getPage(route.params.page.id));
     // make sure the page updates, when the store changes
     const subscription = InfopagesStore.subscribe(() => {
-      setPage(getPage(route.params.page.id));
+      setPage(InfopagesStore.getPage(route.params.page.id));
     })
     return () => {
       subscription.unsubscribe();
     };
   }, []);
 
-  function getPage(id: number): IPage|null {
-      let pages = InfopagesStore.get().filter(page => page.id === id);
-      return pages.length > 0 ? pages[0] : null;
-  }
   if (!page) {
     return null;
   }

--- a/src/components/infos/pages/GenericPage.tsx
+++ b/src/components/infos/pages/GenericPage.tsx
@@ -38,7 +38,7 @@ export default function GenericPage({navigation, page}: Props) {
           </PageHeader>
         </TouchableOpacity>
         <PageContent>
-          <MovaMarkdown>{page.content}</MovaMarkdown>
+          <MovaMarkdown navigation={navigation}>{page.content}</MovaMarkdown>
         </PageContent>
       </PageContainer>
     </PageRefreshScrollView>

--- a/src/stores/InfopagesStore.ts
+++ b/src/stores/InfopagesStore.ts
@@ -27,6 +27,10 @@ export const InfopagesStore = {
 	subscribe: (setState: any) => subject.subscribe(setState),
 	reload: () => {
 		return loadPages();
+	},
+	getPage: (id: number): IPage|null => {
+		const filteredPages = pages.filter(page => page.id === id);
+		return filteredPages.length > 0 ? filteredPages[0] : null;
 	}
 }
 


### PR DESCRIPTION
A markdown links like [this](77) will open child page with DB id 77.

In the Directus data model, a new public field `sub_page: boolean`
is required.