### PR TITLE
Basic offline mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.13.2",
     "@react-native-community/masked-view": "^0.1.10",
+    "@react-native-community/netinfo": "^8.3.0",
     "@react-navigation/bottom-tabs": "^5.7.2",
     "@react-navigation/native": "^5.7.1",
     "@react-navigation/stack": "^5.7.1",

--- a/src/components/news/NewsFeed.tsx
+++ b/src/components/news/NewsFeed.tsx
@@ -5,9 +5,9 @@ import NewsFeedItem from './NewsFeedItem';
 import MovaHeadingText from '../generic/MovaHeadingText';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {INews} from './INews';
-import appConfig from '../../appConfig';
 import languageManager from '../../helpers/LanguageManager';
 import LanguageManager from '../../helpers/LanguageManager';
+import { BackendProxy } from '../../helpers/BackendProxy';
 
 const MainContainer = styled.SafeAreaView`
   background-color: #fff;
@@ -20,12 +20,11 @@ const NewsHeader = styled.View`
 `;
 
 async function loadNews(): Promise<INews[]> {
-  return fetch(
-    appConfig.backendUrl + '/items/news?fields=*.*&sort=-date&filter[language]=' + (await languageManager.getCurrentLanguageAsync()),
+  return BackendProxy.fetchJson(
+    'items/news?fields=*.*&sort=-date&filter[language]=' + (await languageManager.getCurrentLanguageAsync()),
   )
-    .then((response) => response.json())
     .then((json) => {
-      return json.data;
+      return json ? json.data : [];
     })
     .catch((error) => {
       console.error(error);
@@ -45,6 +44,7 @@ export default function NewsMain({navigation}: {navigation: NavigationProp}) {
   useEffect(() => {
     loadNews().then((response) => setNews(response));
     LanguageManager.onChange.subscribe(() => onRefresh());
+    BackendProxy.subscribe(onRefresh);
   }, []);
 
   function onRefresh() {

--- a/src/helpers/BackendProxy.ts
+++ b/src/helpers/BackendProxy.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from "@react-native-community/netinfo";
+import appConfig from '../appConfig';
+
+const fetchJson = async (url: string) => {
+	const fullUrl = `${appConfig.backendUrl}/${url}`;
+	const state = await NetInfo.fetch();
+	if (state && state.isConnected) {
+		return fetchJsonOnlineOrOffline(fullUrl);
+	} else {
+		return fetchJsonOffline(fullUrl);
+	}
+}
+
+const fetchJsonOffline = async (url: string) => AsyncStorage.getItem(url).then(s => {
+	if (s) {
+		return JSON.parse(s);
+	}
+	else {
+		throw 'No data cached offline';
+	}
+});
+
+/** Attempt to fetch data online. Fall back to offline storage if reading online fails. */
+const fetchJsonOnlineOrOffline = async (url: string) => {
+	const response = await fetch(url).catch(
+		error => {
+			// Ignore error, offline data will be used.
+			console.debug(error)
+		}
+	);
+	if (response && response.ok) {
+		const json = await response.json();
+		// Store in the background
+		AsyncStorage.setItem(url, JSON.stringify(json)).catch(
+			error => console.error(error)
+		);
+		// Display data immediately
+		return json;
+	} else {
+		return fetchJsonOffline(url);
+	}
+};
+
+export const BackendProxy = {
+	/** Serve requests for the backend server. Whenever possible, requests are sent
+	 * directly to the server. If offline, previously retrieved data is served from
+	 * locally persisted storage. */
+	fetchJson: async (url: string) => fetchJson(url).catch(
+		error => console.error(error)
+	),
+	/** Subscribe to arrival of new data. */
+	subscribe: (f: () => void) => {
+		return NetInfo.addEventListener(state => {
+			if (state.isConnected) {
+				f();
+			}
+		});
+	}
+}

--- a/src/stores/InfopagesStore.ts
+++ b/src/stores/InfopagesStore.ts
@@ -1,18 +1,17 @@
 import {IPage} from '../components/infos/IPage';
-import appConfig from '../appConfig';
 import languageManager from '../helpers/LanguageManager';
 import {Subject} from 'rxjs';
 import LanguageManager from '../helpers/LanguageManager';
+import {BackendProxy} from '../helpers/BackendProxy';
 
 const subject = new Subject();
 
 let pages: IPage[] = [];
 
 async function loadPages(): Promise<void> {
-	fetch(appConfig.backendUrl + '/items/pages?filter[language]=' + (await languageManager.getCurrentLanguageAsync()))
-		.then((response) => response.json())
+	BackendProxy.fetchJson('items/pages?filter[language]=' + (await languageManager.getCurrentLanguageAsync()))
 		.then((json) => {
-			pages = json.data;
+			pages = json ? json.data : [];
 			subject.next(pages);
 		})
 		.catch((error) => {
@@ -21,6 +20,7 @@ async function loadPages(): Promise<void> {
 }
 
 LanguageManager.onChange.subscribe(() => loadPages());
+BackendProxy.subscribe(loadPages);
 
 export const InfopagesStore = {
 	get: () => pages,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.11.tgz#2f4c6e10bee0786abff4604e39a37ded6f3980ce"
   integrity sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==
 
+"@react-native-community/netinfo@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-8.3.0.tgz#e3d19381c7d9f885b44ea1785ed892bc39c4b0f1"
+  integrity sha512-VlmjD7Vg1BacbNhwuJCel1eeD8N2Ps6BEcZe9qoSoeIptpCbC86o4ZqD0meSjJzioKSvgalrkmPgMaVYsVipKw==
+
 "@react-native/assets@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets/-/assets-1.0.0.tgz#c6f9bf63d274bafc8e970628de24986b30a55c8e"


### PR DESCRIPTION
News und Infoseiten werden gecached und persistiert.
Daten werden falls Verbindung vorhanden trotzdem immer vom Server geladen.

Es werden keine Daten geladen nur für den Cache. Man kann also nur anschauen,
was man schon einmal gesehen hat. Das ist glaub auch gut so.

Was noch ergänzt werden könnte:
- Visueller Hinweis, dass man offline ist und alte Daten sieht.
- Grössenlimits auf Android könnte man besser handhaben.
  Siehe dazu https://react-native-async-storage.github.io/async-storage/docs/limits